### PR TITLE
Fixed Regexp to not use ECMAScript 2018 features

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -75,16 +75,25 @@ function DateTime(datetime, hasDate) {
 }
 
 d_input = function(input_text) {
-  let time_regex = /^(?<fullDate>\d{4}[/-]\d{1,2}[/-]\d{1,2}\s|\d{1,2}[/-]\d{1,2}[/-]\d{4}\s)?(?<hour>[0-9]?[0-9])[: ]?(?<min>[0-5][0-9])?\s?[: ]?(?<sec>[0-5][0-9])?\s?(?<ampm>[aApP][mM]?)?\s?(?<tz>[a-zA-Z /_-]+)?$/i
+  const time_regex = /^(\d{4}[/-]\d{1,2}[/-]\d{1,2}\s|\d{1,2}[/-]\d{1,2}[/-]\d{4}\s)?([0-9]?[0-9])[: ]?([0-5][0-9])?\s?[: ]?([0-5][0-9])?\s?([aApP][mM]?)?\s?([a-zA-Z /_-]+)?$/i
+  // ECMAScript 2018 Regexp named groups (Chrome support, but no FF support as of 2019-02-23)
+  // const time_regex = /^(?<fullDate>\d{4}[/-]\d{1,2}[/-]\d{1,2}\s|\d{1,2}[/-]\d{1,2}[/-]\d{4}\s)?(?<hour>[0-9]?[0-9])[: ]?(?<min>[0-5][0-9])?\s?[: ]?(?<sec>[0-5][0-9])?\s?(?<ampm>[aApP][mM]?)?\s?(?<tz>[a-zA-Z /_-]+)?$/i
   if (time_regex.test(input_text) == true) {
-    var t = time_regex.exec(input_text).groups
-    let timezone = (typeof t.tz == 'undefined') ? spacetime().timezone().name : t.tz
+    // var t = time_regex.exec(input_text).groups
+    var t = time_regex.exec(input_text) 
+    // let timezone = (typeof t.tz == 'undefined') ? spacetime().timezone().name : t.tz
+    let timezone = (typeof t[6] == 'undefined') ? spacetime().timezone().name : t[6] // t.tz
      dt = new DateTime(spacetime({
-        iso: (typeof t.fullDate == 'undefined') ? spacetime.now().format('iso-short') : spacetime(t.fullDate).format('iso-short'),
-        hour: (typeof t.hour == 'undefined') ? 0 : t.hour,
-        minute: (typeof t.min == 'undefined') ? 0 : t.min,
-        second: (typeof t.sec == 'undefined') ? 0 : t.sec,
-        ampm: (typeof t.ampm == 'undefined') ? null : (t.ampm + 'm').slice(0,2) //allows parsing '9a' or '9p'
+        // iso: (typeof t.fullDate == 'undefined') ? spacetime.now().format('iso-short') : spacetime(t.fullDate).format('iso-short'),
+        iso: (typeof t[1] == 'undefined') ? spacetime.now().format('iso-short') : spacetime(t[1]).format('iso-short'),
+        // hour: (typeof t.hour == 'undefined') ? 0 : t.hour,
+        hour: (typeof t[2] == 'undefined') ? 0 : t[2],
+        // minute: (typeof t.min == 'undefined') ? 0 : t.min,
+        minute: (typeof t[3] == 'undefined') ? 0 : t[3],
+        // second: (typeof t.sec == 'undefined') ? 0 : t.sec,
+        second: (typeof t[4] == 'undefined') ? 0 : t[4],
+        // ampm: (typeof t.ampm == 'undefined') ? null : (t.ampm + 'm').slice(0,2) //allows parsing '9a' or '9p'
+        ampm: (typeof t[5] == 'undefined') ? null : (t[5] + 'm').slice(0,2) //allows parsing '9a' or '9p'
       },
       timezone,
       {
@@ -92,7 +101,7 @@ d_input = function(input_text) {
         quiet: true
       }
       ),
-      (typeof t.fullDate === 'undefined') ? false : true)
+      (typeof t[1] === 'undefined') ? false : true)
   } else {
     dt = new DateTime(spacetime(input_text), true)
   }


### PR DESCRIPTION
Previous version used regexp named capture groups, which is currently only supported in Chrome.
https://github.com/tc39/proposal-regexp-named-groups

Commented-out the named groups (I like the ability to name, so I want to reintroduce this if/when the proposal is better supported) and switched to using array references.

```javascript
// hour: (typeof t.hour == 'undefined') ? 0 : t.hour,
        hour: (typeof t[2] == 'undefined') ? 0 : t[2],
```

Ideally, this can be fixed by making a better input parser instead of relying on a really long regex (#4).